### PR TITLE
Use generic spotless target

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -12,7 +12,7 @@
     pass_filenames: false
 -   id: gradle-spotless
     name: gradle spotless
-    description: Lints java project using "gradle spotlessJavaCheck spotlessJavaApply"
+    description: Lints the project using "gradle spotlessCheck spotlessApply"
     entry: gradle-spotless
     language: python
     pass_filenames: false

--- a/pre_commit_hooks/gradle_spotless.py
+++ b/pre_commit_hooks/gradle_spotless.py
@@ -20,9 +20,9 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
     args = parser.parse_args(argv)
 
     if args.wrapper:
-        return run_gradle_wrapper_task(args.output, 'spotlessJavaCheck', 'spotlessJavaApply')
+        return run_gradle_wrapper_task(args.output, 'spotlessCheck', 'spotlessApply')
     else:
-        return run_gradle_task(args.output, 'spotlessJavaCheck', 'spotlessJavaApply')
+        return run_gradle_task(args.output, 'spotlessCheck', 'spotlessApply')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi Jack,

thanks for providing pre-commit hooks for Gradle! Because the target for Spotless is specific to Java I could not use it on my Kotlin projects so I changed it to use the generic targets. It seems to work fine for both types of projects.

Best,

Manuel